### PR TITLE
Add config option to provide a proxy client name for results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Config option to provide a proxy client name for rspec results
 
 ## [1.0.0] - 2017-07-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run only one set of tests
 
 Run tests with all options (except environment variables)
 
-`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec -p rspec-client`
+`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec --proxy-client rspec-client`
 
 Run tests with required options and multiple environment variables
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run only one set of tests
 
 Run tests with all options (except environment variables)
 
-`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec`
+`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec -p rspec-client`
 
 Run tests with required options and multiple environment variables
 

--- a/bin/check-rspec.rb
+++ b/bin/check-rspec.rb
@@ -77,10 +77,9 @@ class CheckRspec < Sensu::Plugin::Check::CLI
          long: '--handler HANDLER',
          default: 'default'
 
-  option :source,
+  option :proxy_client,
          description: 'Proxy client name for results',
-         short: '-p SOURCE',
-         long: '--proxy SOURCE',
+         long: '--proxy-client SOURCE',
          required: false
 
   def sensu_client_socket(msg)
@@ -89,12 +88,12 @@ class CheckRspec < Sensu::Plugin::Check::CLI
   end
 
   def send_ok(check_name, msg)
-    d = { 'name' => check_name, 'status' => 0, 'output' => "OK: #{msg}", 'handler' => config[:handler], 'source' => config[:source] }
+    d = { 'name' => check_name, 'status' => 0, 'output' => "OK: #{msg}", 'handler' => config[:handler], 'source' => config[:proxy_client] }
     sensu_client_socket d.to_json
   end
 
   def send_warning(check_name, msg)
-    d = { 'name' => check_name, 'status' => 1, 'output' => "WARNING: #{msg}", 'handler' => config[:handler], 'source' => config[:source] }
+    d = { 'name' => check_name, 'status' => 1, 'output' => "WARNING: #{msg}", 'handler' => config[:handler], 'source' => config[:proxy_client] }
     sensu_client_socket d.to_json
   end
 

--- a/bin/check-rspec.rb
+++ b/bin/check-rspec.rb
@@ -77,18 +77,24 @@ class CheckRspec < Sensu::Plugin::Check::CLI
          long: '--handler HANDLER',
          default: 'default'
 
+  option :source,
+         description: 'Proxy client name for results',
+         short: '-p SOURCE',
+         long: '--proxy SOURCE',
+         required: false
+
   def sensu_client_socket(msg)
     u = UDPSocket.new
     u.send(msg + "\n", 0, '127.0.0.1', 3030)
   end
 
   def send_ok(check_name, msg)
-    d = { 'name' => check_name, 'status' => 0, 'output' => "OK: #{msg}", 'handler' => config[:handler] }
+    d = { 'name' => check_name, 'status' => 0, 'output' => "OK: #{msg}", 'handler' => config[:handler], 'source' => config[:source] }
     sensu_client_socket d.to_json
   end
 
   def send_warning(check_name, msg)
-    d = { 'name' => check_name, 'status' => 1, 'output' => "WARNING: #{msg}", 'handler' => config[:handler] }
+    d = { 'name' => check_name, 'status' => 1, 'output' => "WARNING: #{msg}", 'handler' => config[:handler], 'source' => config[:source] }
     sensu_client_socket d.to_json
   end
 


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

`check-rspec.rb` makes use of the Sensu client socket to send individual check results for each given Rspec test. Due to this, setting a source/proxy client within the check definition itself has no affect, as the individual results are sent 'separately' to the socket, and will always appear as a check result for the host that the check was ran on.

This change introduces an additional config option to specify a source/proxy client so that all Rspec results can be correctly sent with the source attribute. This has to be a config option as the plugin does not have context on the check attributes, so it is not possible to read in the source attribute from the check definition if present (i.e. https://github.com/sensu/sensu/issues/1586)

The `source` attribute is included in the result regardless of whether the config option is specified (as opposed to adding a case statement or something similar), however when not specified this value results to null, which the client silently ignores.

#### Known Compatability Issues

This should have no compatibility issues; checks not using this new flag will have the source value set to null, which will result in no behavioural differences at runtime.

