### PR TITLE
Add option to add index number to results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Removed
 - Ruby 1.9.3 from deploy-time testing (@eheydrick)
 
-### Added
-- Config option to add index value to results to prevent duplicate tests overwriting each other
+### Breaking Changes
+- Check result names will now be appended with a unique index value to ensure a unique namespace for all results
 
 ## [1.1.0] - 2017-07-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Removed
 - Ruby 1.9.3 from deploy-time testing (@eheydrick)
 
+### Added
+- Config option to add index value to results to prevent duplicate tests overwriting each other
+
 ## [1.1.0] - 2017-07-15
 ### Added
 - Config option to provide a proxy client name for rspec results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Removed
+- Ruby 1.9.3 from deploy-time testing (@eheydrick)
 
-## [1.1.0] 2017-07-15
+## [1.1.0] - 2017-07-15
 ### Added
 - Config option to provide a proxy client name for rspec results
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run only one set of tests
 
 Run tests with all options (except environment variables)
 
-`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec --proxy-client rspec-client --index-results`
+`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec --proxy-client rspec-client`
 
 Run tests with required options and multiple environment variables
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run only one set of tests
 
 Run tests with all options (except environment variables)
 
-`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec --proxy-client rspec-client`
+`check-rspec -b /usr/bin/ruby -i bin/rspec -d /tmp/my_tests -s spec --proxy-client rspec-client --index-results`
 
 Run tests with required options and multiple environment variables
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Sensu-Plugins-rspec
 
-[ ![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-rspec.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-rspec)
+[![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-rspec.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-rspec)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-rspec.svg)](http://badge.fury.io/rb/sensu-plugins-rspec)
 [![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-rspec/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-rspec)
 [![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-rspec/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-rspec)

--- a/bin/check-rspec.rb
+++ b/bin/check-rspec.rb
@@ -82,11 +82,6 @@ class CheckRspec < Sensu::Plugin::Check::CLI
          long: '--proxy-client SOURCE',
          required: false
 
-  option :index_results,
-         description: 'Append extra index value to rspec results',
-         long: '--index-results',
-         default: false
-
   def sensu_client_socket(msg)
     u = UDPSocket.new
     u.send(msg + "\n", 0, '127.0.0.1', 3030)
@@ -110,12 +105,7 @@ class CheckRspec < Sensu::Plugin::Check::CLI
     parsed        = JSON.parse(rspec_results)
 
     parsed['examples'].each_with_index do |rspec_test, index|
-      test_name = case config[:index_results]
-                  when true
-                    rspec_test['file_path'].split('/')[-1] + '_' + rspec_test['line_number'].to_s + '_' + index.to_s
-                  else
-                    rspec_test['file_path'].split('/')[-1] + '_' + rspec_test['line_number'].to_s
-                  end
+      test_name = rspec_test['file_path'].split('/')[-1] + '_' + rspec_test['line_number'].to_s + '_' + index.to_s
       output = rspec_test['full_description']
 
       if rspec_test['status'] == 'passed'


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

`check-rspec.rb` currently generates the check name using a combination of the check file (i.e. default_spec.rb) & the line number of the check, resulting in something like: `default_spec.rb_23`

In our environment we have some Rspec tests that are repeated by looping through a given set of data (i.e. to check an expected list of users exists in AWS):

```
  iam[environment][:users].each do |user|
    describe iam_user(user[:name]) do
      it { should exist }
      case user[:policy_type]
      when 'inline'
        it { should have_inline_policy(user[:policy_name]) }
      when 'iam'
        it { should have_iam_policy(user[:policy_name]) }
      end
    end
  end
```

The use of this method means that there are multiple Rspec results that are from the same line number. As a result multiple results are sent to the Sensu socket with the same name, and they ultimately overwrite each other.

This proposed change adds an addition boolean value (`--index-results`) that will add the index number of the loop to the check result, giving completely unique check names, preventing conflicts in the checks.

This is just a first pass -- I'm open to alternative suggestions to achieve this (Different value to append to checks, different option etc.), or even suggestions if the Rspec tests I'm running should actually be different.

#### Known Compatability Issues

Existing behaviour will remain the same unless this additional config option is specified.

